### PR TITLE
Configure additional tags per series in influxdb

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -58,6 +58,10 @@ influxdb_publisher:
   bucket: ruuvi
   # Measurement name to use
   measurement: ruuvi_measurements
+  # Uncomment to add additional tags to a series
+  #additional_tags:
+  #  mytag: myvalue
+  #  myothertag: myothervalue
 
 # Prometheus exporter for data
 prometheus:

--- a/config/config.go
+++ b/config/config.go
@@ -38,13 +38,14 @@ type Processing struct {
 }
 
 type InfluxDBPublisher struct {
-	Enabled         *bool         `yaml:"enabled,omitempty"`
-	MinimumInterval time.Duration `yaml:"minimum_interval,omitempty"`
-	Url             string        `yaml:"url"`
-	AuthToken       string        `yaml:"auth_token"`
-	Org             string        `yaml:"org"`
-	Bucket          string        `yaml:"bucket"`
-	Measurement     string        `yaml:"measurement"`
+	Enabled         *bool             `yaml:"enabled,omitempty"`
+	MinimumInterval time.Duration     `yaml:"minimum_interval,omitempty"`
+	Url             string            `yaml:"url"`
+	AuthToken       string            `yaml:"auth_token"`
+	Org             string            `yaml:"org"`
+	Bucket          string            `yaml:"bucket"`
+	Measurement     string            `yaml:"measurement"`
+	AdditionalTags  map[string]string `yaml:"additional_tags,omitempty"`
 }
 
 type Prometheus struct {

--- a/data_sinks/influxdb.go
+++ b/data_sinks/influxdb.go
@@ -51,6 +51,9 @@ func InfluxDB(conf config.InfluxDBPublisher) chan<- parser.Measurement {
 			if measurement.Name != nil {
 				p.AddTag("name", *measurement.Name)
 			}
+			for tag, value := range conf.AdditionalTags {
+				p.AddTag(tag, value)
+			}
 			addFloat(p, "temperature", measurement.Temperature)
 			addFloat(p, "humidity", measurement.Humidity)
 			addFloat(p, "pressure", measurement.Pressure)


### PR DESCRIPTION
This allows to add arbitrary tags per series. I use that to add more information about the data, like the location the ruuvi tags are located which this instance of the ruuvibridge processes.