### PR TITLE
Update mqtt_homeassistant.go

### DIFF
--- a/data_sinks/mqtt_homeassistant.go
+++ b/data_sinks/mqtt_homeassistant.go
@@ -53,7 +53,7 @@ func publishHomeAssistantDiscoveries(client mqtt.Client, conf config.MQTTPublish
 		Available:         measurement.Temperature != nil,
 		DeviceClass:       "temperature",
 		NamePostfix:       "temperature",
-		UnitOfMeasurement: "ºC",
+		UnitOfMeasurement: "°C",
 		JsonAttribute:     "temperature",
 	})
 	publishHomeAssistantDiscovery(client, conf, measurement, homeassistantDiscoveryConfig{
@@ -123,7 +123,7 @@ func publishHomeAssistantDiscoveries(client mqtt.Client, conf config.MQTTPublish
 		Available:         measurement.DewPoint != nil,
 		DeviceClass:       "temperature",
 		NamePostfix:       "dew point",
-		UnitOfMeasurement: "ºC",
+		UnitOfMeasurement: "°C",
 		JsonAttribute:     "dewPoint",
 	})
 	publishHomeAssistantDiscovery(client, conf, measurement, homeassistantDiscoveryConfig{


### PR DESCRIPTION
Temperature related UnitOfMeasurement i.e. degree character seems to be coded as (U+00BA). I think correct one is (U+00B0). Using (U+00BA) as s degree character looked weird in Home Assistant:

![image](https://user-images.githubusercontent.com/25028729/165537689-740ea273-3001-4971-883d-279f74b54dc2.png)

..and it was not possible to move the sensor to Homekit without customizing the entity.