### PR TITLE
gateway_polling: Implemented support for an optional bearer token

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -3,6 +3,8 @@ gateway_polling:
   # Flag to enable or disable gateway polling
   enabled: false
   gateway_url: http://ip.or.hostname.of.the.gateway
+  # If you have enabled authentication on the gateway, specify the API key (bearer token) from the gateway Access Settings configuration page
+  bearer_token: ""
   interval: 10s
 
 # Recommended option: Have the gateway send the measurements to a MQTT server and let RuuviBridge subscribe to updates in real time

--- a/config/config.go
+++ b/config/config.go
@@ -10,9 +10,10 @@ import (
 )
 
 type GatewayPolling struct {
-	Enabled    *bool         `yaml:"enabled,omitempty"`
-	GatewayUrl string        `yaml:"gateway_url"`
-	Interval   time.Duration `yaml:"interval"`
+	Enabled     *bool         `yaml:"enabled,omitempty"`
+	GatewayUrl  string        `yaml:"gateway_url"`
+	BearerToken string        `yaml:"bearer_token"`
+	Interval    time.Duration `yaml:"interval"`
 }
 
 type MQTTListener struct {


### PR DESCRIPTION
Simply specify gateway_polling.bearer_token and off you go. Empty
(and missing) value disables it.