### PR TITLE
feat: publish each measurement to its own topic

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -95,6 +95,10 @@ mqtt_publisher:
   # Topic prefix where to publish, in format <topic_prefix>/<mac>
   # If you use the same server for a source, be sure to use a differnet topic prefix to avoid conflicts!
   topic_prefix: ruuvitag
+  # Publish each measurement to its own topic so no JSON parsing is needed on the consumer side. This will publish
+  # to <topic_prefix>/<mac>/temperature, <topic_prefix>/<mac>/humidity, and so forth. When enabled, these are
+  # published in addition to the JSON string which is published to <topic_prefix>/<mac>, not in place of them.
+  publish_raw: false
   # Topic where to publish LWT "status messages" on connect/disconnect. Empty means disabled.
   # Note that the mqtt_listener and mqtt_publisher have their own distinct connections and you should not use the same lwt topic for both.
   lwt_topic: ""

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ type MQTTPublisher struct {
 	Username                     string        `yaml:"username"`
 	Password                     string        `yaml:"password"`
 	TopicPrefix                  string        `yaml:"topic_prefix"`
+	PublishRaw                   bool          `yaml:"publish_raw"`
 	HomeassistantDiscoveryPrefix string        `yaml:"homeassistant_discovery_prefix,omitempty"`
 	LWTTopic                     string        `yaml:"lwt_topic"`
 	LWTOnlinePayload             string        `yaml:"lwt_online_payload"`

--- a/data_sinks/mqtt.go
+++ b/data_sinks/mqtt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Scrin/RuuviBridge/parser"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	log "github.com/sirupsen/logrus"
+	"strconv"
 )
 
 func MQTT(conf config.MQTTPublisher) chan<- parser.Measurement {
@@ -82,6 +83,37 @@ func MQTT(conf config.MQTTPublisher) chan<- parser.Measurement {
 				client.Publish(conf.TopicPrefix+"/"+measurement.Mac, 0, false, string(data))
 				if conf.HomeassistantDiscoveryPrefix != "" {
 					publishHomeAssistantDiscoveries(client, conf, measurement)
+				}
+				if conf.PublishRaw {
+					safePublishF := func(label string, v *float64) {
+						if v != nil {
+							client.Publish(conf.TopicPrefix+"/"+measurement.Mac+"/"+label, 0, false, strconv.FormatFloat(*v, 'f', -1, 64))
+						}
+					}
+					safePublishI := func(label string, v *int64) {
+						if v != nil {
+							client.Publish(conf.TopicPrefix+"/"+measurement.Mac+"/"+label, 0, false, strconv.FormatInt(*v, 10))
+						}
+					}
+					safePublishF("temperature", measurement.Temperature)
+					safePublishF("humidity", measurement.Humidity)
+					safePublishF("pressure", measurement.Pressure)
+					safePublishF("accelerationX", measurement.AccelerationX)
+					safePublishF("accelerationY", measurement.AccelerationY)
+					safePublishF("accelerationZ", measurement.AccelerationZ)
+					safePublishF("batteryVoltage", measurement.BatteryVoltage)
+					safePublishI("txPower", measurement.TxPower)
+					safePublishI("rssi", measurement.Rssi)
+					safePublishI("movementCounter", measurement.MovementCounter)
+					safePublishI("measurementSequenceNumber", measurement.MeasurementSequenceNumber)
+					safePublishF("accelerationTotal", measurement.AccelerationTotal)
+					safePublishF("absoluteHumidity", measurement.AbsoluteHumidity)
+					safePublishF("dewPoint", measurement.DewPoint)
+					safePublishF("equilibriumVaporPressure", measurement.EquilibriumVaporPressure)
+					safePublishF("airDensity", measurement.AirDensity)
+					safePublishF("accelerationAngleFromX", measurement.AccelerationAngleFromX)
+					safePublishF("accelerationAngleFromY", measurement.AccelerationAngleFromY)
+					safePublishF("accelerationAngleFromZ", measurement.AccelerationAngleFromZ)
 				}
 			}
 		}


### PR DESCRIPTION
This change implements what was discussed in #11 and should close the ticket. Default is the same behavior as exists now, and config.sample.yml also shows this new feature as being disabled.

I've compiled this and tested it, so I know it is functional

Please do take a look over the code, as I'm new to Go programming, so I don't understand every little detail. For example, I'm not sure why some boolean fields in the config appear to be pointers and other appear to be values. However, since I tested the changes, I expect if any changes are desired, they will be style related, not functional.